### PR TITLE
Add the new icu4c source location

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -15,7 +15,10 @@
 LOCAL_PATH:= $(call my-dir)
 
 include $(CLEAR_VARS)
-LOCAL_C_INCLUDES := external/libxml2/include external/icu4c/common
+LOCAL_C_INCLUDES := \
+	external/libxml2/include \
+	external/icu4c/common/ \
+	external/icu/icu4c/source/common
 LOCAL_SRC_FILES := \
 	src/configuration.c \
 	src/control.c \


### PR DESCRIPTION
- Needed after external/icu commit c73f511526464f8e56c242df80552e9b0d94ae3d
  "Move the icu4c source to match the upstream layout."

Change-Id: I3152e41d6979b8fb5735f08894f7ebdc2c5d4f18

Needed for building with AOSP master.
