### PR TITLE
mitigation: add fallback resources

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -168,6 +168,7 @@ static int parse_one_mitigation_resource(void *data, const struct dom_obj *obj)
 {
 	struct mitigation *mig;
 	const char *name;
+	const char *fallback;
 
 	name = dom_obj_attribute_value(obj, "resource");
 	if (name == NULL) {
@@ -175,8 +176,10 @@ static int parse_one_mitigation_resource(void *data, const struct dom_obj *obj)
 		return -1;
 	}
 
+	fallback = dom_obj_attribute_value(obj, "fallback");
+
 	mig = (struct mitigation *)data;
-	mitigation_add_resource(mig, name, obj->content ? obj->content : "");
+	mitigation_add_resource(mig, name, obj->content ? obj->content : "", fallback);
 
 	return 0;
 }

--- a/src/mitigation.h
+++ b/src/mitigation.h
@@ -5,6 +5,7 @@
 
 struct mitigation {
 	struct list resources;
+	struct list fallback_resources;
 	int level;
 	struct list_node list_node;
 };
@@ -13,7 +14,7 @@ struct mitigation *mitigation_create(int level);
 void mitigation_destroy(struct mitigation *m);
 
 void mitigation_add_resource(struct mitigation *m,
-		const char *name, const char *target_value);
+		const char *name, const char *target_value, const char *fallback);
 void mitigation_activate(struct mitigation *m);
 void mitigation_deactivate(struct mitigation *m);
 


### PR DESCRIPTION
It has been observed, that mitigations would fail in certain situations.
The specific situation observed was that writing invalid paramters to the cpuquiet sysfs resource nr_thermal_max_cpus.
The kernel would refuse such writes, rendering the mitigation applied nonfunctional.
This can be dangerous when the mitigation is critical for device health.
In order to make sure mitigations always apply, this commit introduces a basic fallback implementation.
An example of a mitigation with a fallback resource:
```
<mitigation level="1">
  <value resource="normal-resource">1</value>
  <value fallback="fallback" resource="fallback-resource">1</value>
</mitigation>
```
If the write of normal-resource fails, then thermanager will write to fallback-resource.

Change-Id: Iad8eae562b3627f9a6ef66bbca35d66c202542b3