### PR TITLE
thermanager: Add sysfs read-only handling and adapt msm-adc

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Resources are used to provide I/O functionality.  There are several different ty
 * "sysfs" - Usually a text file in /sys which holds a value, or can have a value written to it.  
 `<resource name="gpu-fan" type="sysfs">/sys/class/fan/gpu0/rpm</resource>`
 
+* "sysfs-ro" - Usually a text file in /sys which holds a read-only value like temperatures.  
+`<resource name="gpu-temp" type="sysfs-ro">/sys/class/fan/gpu0/temp</resource>`
+
 * "tz" - A thermal zone directory for reading temperatures.  
 `<resource name="zone0" type="tz">/sys/class/thermal/thermal_zone0</resource>`
 

--- a/src/main.c
+++ b/src/main.c
@@ -110,7 +110,11 @@ static int parse_one_resource(void *data, const struct dom_obj *obj)
 	} else if (!strcmp(type, "sysfs")) {
 		if (obj->content == NULL)
 			return -1;
-		res = resource_sysfs_open(name, obj->content);
+		res = resource_sysfs_open(name, obj->content, RESOURCE_SYSFS_RDWR);
+	} else if (!strcmp(type, "sysfs-ro")) {
+		if (obj->content == NULL)
+			return -1;
+		res = resource_sysfs_open(name, obj->content, RESOURCE_SYSFS_RDONLY);
 	} else if (!strcmp(type, "deadband")) {
 		const char *alias;
 		const char *ssize;

--- a/src/resource.h
+++ b/src/resource.h
@@ -3,6 +3,11 @@
 
 #include "list.h"
 
+enum resource_sysfs_t {
+	RESOURCE_SYSFS_RDONLY,
+	RESOURCE_SYSFS_RDWR,
+};
+
 struct resource {
 	char name[256];
 
@@ -24,7 +29,8 @@ void resource_manager_remove(struct resource *res);
 void resource_manager_prepare(void);
 
 struct resource *resource_tz_open(const char *name, const char *file);
-struct resource *resource_sysfs_open(const char *name, const char *file);
+struct resource *resource_sysfs_open(const char *name, const char *file,
+		enum resource_sysfs_t sysfs_type);
 struct resource *resource_union_open(const char *name,
 		int count, const char **children_names);
 struct resource *resource_alias_open(const char *name, const char *aliased);


### PR DESCRIPTION
 * Add 'sysfs-ro' type for read-only paths like temperatures
 * Keep original read/write handling of 'sysfs'
 * Use read-only option for msm-adc as per documentation
 * Allows resolving dac_override sepolicy denials

Change-Id: I692c9cadd5a609655e993f21a5f7caf3ef3c5bef
Signed-off-by: Adrian DC <radian.dc@gmail.com>