### PR TITLE
thermanager: move to vendor

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -37,6 +37,10 @@ LOCAL_SHARED_LIBRARIES := liblog libicuuc libcutils
 LOCAL_STATIC_LIBRARIES := libxml2
 LOCAL_MODULE := thermanager
 LOCAL_MODULE_TAGS := optional
+ifeq (1,$(filter 1,$(shell echo "$$(( $(PLATFORM_SDK_VERSION) >= 25 ))" )))
+LOCAL_MODULE_OWNER := sony
+LOCAL_PROPRIETARY_MODULE := true
+endif
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)


### PR DESCRIPTION
system for aosp stuff
vendor for OSS stuff
odm for prebuilt libs provided by OEM

make sure it will be used since api level 25 n-mr1

Signed-off-by: David Viteri <davidteri91@gmail.com>