### PR TITLE
thermanager: Ignore unused data variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS := -Wall -g -I/usr/include/libxml2
+CFLAGS := -Wall -Wunused-parameter -g -I/usr/include/libxml2
 LDFLAGS := -l xml2
 
 proj := thermanager

--- a/src/main.c
+++ b/src/main.c
@@ -61,7 +61,8 @@ static int parse_multi_X(const struct dom_obj *obj, const char *name,
 	return 0;
 }
 
-static int parse_one_resource(void *data, const struct dom_obj *obj)
+static int parse_one_resource(void *data __attribute__ ((__unused__)),
+		const struct dom_obj *obj)
 {
 	struct resource *res;
 	const char *type;

--- a/src/resource.c
+++ b/src/resource.c
@@ -572,7 +572,8 @@ struct halt_resource {
 	int delay;
 };
 
-static void resource_halt_cb(void *data, struct watch_ticket *ticket)
+static void resource_halt_cb(void *data __attribute__ ((__unused__)),
+		struct watch_ticket *ticket)
 {
 	//struct halt_resource *ares = (struct halt_resource)data;
 	watch_ticket_delete(ticket);


### PR DESCRIPTION
 * Ignore unused variables required by the APIs

 * src/main.c:64:37:
    error: unused parameter 'data'

 * src/resource.c:575:36:
    error: unused parameter 'data'

Change-Id: I9ad3c25e203ba9df4315d4a650efec5ff513e967