### PR TITLE
thermanager: APEX compatibility

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -33,7 +33,7 @@ LOCAL_SRC_FILES := \
 	src/util.c \
 	src/main.c \
 
-LOCAL_SHARED_LIBRARIES := liblog libicuuc libcutils
+LOCAL_SHARED_LIBRARIES := liblog libandroidicu libcutils
 LOCAL_STATIC_LIBRARIES := libxml2
 LOCAL_MODULE := thermanager
 LOCAL_MODULE_TAGS := optional

--- a/Android.mk
+++ b/Android.mk
@@ -33,7 +33,12 @@ LOCAL_SRC_FILES := \
 	src/util.c \
 	src/main.c \
 
-LOCAL_SHARED_LIBRARIES := liblog libandroidicu libcutils
+ifeq (1,$(filter 1,$(shell echo "$$(( $(PLATFORM_SDK_VERSION) >= 29 ))" )))
+LOCAL_SHARED_LIBRARIES := libandroidicu
+else
+LOCAL_SHARED_LIBRARIES := libicuuc
+endif # Guard building for legacy Android
+LOCAL_SHARED_LIBRARIES += liblog libcutils
 LOCAL_STATIC_LIBRARIES := libxml2
 LOCAL_MODULE := thermanager
 LOCAL_MODULE_TAGS := optional


### PR DESCRIPTION
Our legacy devices are still alive on kernel 4.9 and 4.4. :D
Without this patch, it will show 
```
  warning:  APEX libraries found in system image (see comment for check-apex-libs-absence in build/make/core/main.mk for details)
  Offending entries:
  system/lib/libicuuc.so
```
`libicuuc.so` has been an apex blob on Android 10, it is not allowed to exist in system partition.

See more : 
https://source.android.google.cn/devices/architecture/modular-system/runtime#icu-libraries