### PR TITLE
Delete unnecessary (transitive) icu dependency for libxml2

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -15,10 +15,6 @@
 LOCAL_PATH:= $(call my-dir)
 
 include $(CLEAR_VARS)
-LOCAL_C_INCLUDES := \
-	external/libxml2/include \
-	external/icu4c/common/ \
-	external/icu/icu4c/source/common
 LOCAL_SRC_FILES := \
 	src/configuration.c \
 	src/control.c \
@@ -33,12 +29,7 @@ LOCAL_SRC_FILES := \
 	src/util.c \
 	src/main.c \
 
-ifeq (1,$(filter 1,$(shell echo "$$(( $(PLATFORM_SDK_VERSION) >= 29 ))" )))
-LOCAL_SHARED_LIBRARIES := libandroidicu
-else
-LOCAL_SHARED_LIBRARIES := libicuuc
-endif # Guard building for legacy Android
-LOCAL_SHARED_LIBRARIES += liblog libcutils
+LOCAL_SHARED_LIBRARIES := liblog libcutils
 LOCAL_STATIC_LIBRARIES := libxml2
 LOCAL_MODULE := thermanager
 LOCAL_MODULE_TAGS := optional

--- a/Android.mk
+++ b/Android.mk
@@ -33,7 +33,7 @@ LOCAL_SHARED_LIBRARIES := liblog libcutils
 LOCAL_STATIC_LIBRARIES := libxml2
 LOCAL_MODULE := thermanager
 LOCAL_MODULE_TAGS := optional
-ifeq (1,$(filter 1,$(shell echo "$$(( $(PLATFORM_SDK_VERSION) >= 25 ))" )))
+ifneq ($(call math_gt_or_eq, $(PLATFORM_SDK_VERSION), 25),)
 LOCAL_MODULE_OWNER := sony
 LOCAL_INIT_RC      := vendor/etc/init/thermanager.rc
 LOCAL_PROPRIETARY_MODULE := true


### PR DESCRIPTION
Libxml2 is perfectly capable of depending on icu and re-exporting the necessary headers in addition to its own headers and make these work fine. We shouldn't worry about this at all.

Linking against libandroidicu on Android R is a hard error as well.

---

Build-tested on Android 10/Q.

@sjllls Since you touched this very recently in #11, would you mind testing if this works for you? What Android versions are you still using this on, just 8 and 9?